### PR TITLE
Use squared symbol for specialization

### DIFF
--- a/src/generate_single_stub_dot.py
+++ b/src/generate_single_stub_dot.py
@@ -14,7 +14,7 @@
 #
 # We would appreciate acknowledgement if the software is used.
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 import argparse
 import hashlib
@@ -251,7 +251,7 @@ digraph "hierarchy" {
             edge_label = {
                 N_HAS_FACET_AT_CLASS_LEVEL: "",
                 NS_RDF.type: "∈",
-                NS_RDFS.subClassOf: "⊂",
+                NS_RDFS.subClassOf: "⊏",
             }[triple[1]]
             head_arrow = {
                 N_HAS_FACET_AT_CLASS_LEVEL: "dot",


### PR DESCRIPTION
This PR revises one symbol used in the figures, and regenerates the figures.

`⊂` was being used to represent `rdfs:subClassOf`, but is visually close to `∈` being used for `rdf:type`.  This impacts use of this script for describing meta-classes (i.e., classes whose members are classes, one possible resolution of [UCO Issue 595](https://github.com/ucoProject/UCO/issues/595)).

`⊏` offers a little more visual distinction from `∈`, and seems sufficiently expandable to also represent specialization of properties (i.e., would be suitable for `rdfs:subClassOf` and `rdfs:subPropertyOf`).